### PR TITLE
修复 HttpParam4Test 使用 jackson 序列化插件错误

### DIFF
--- a/__test/src/main/java/webapp/models/UserD.java
+++ b/__test/src/main/java/webapp/models/UserD.java
@@ -1,6 +1,8 @@
 package webapp.models;
 
-public final class UserD {
+import java.io.Serializable;
+
+public final class UserD implements Serializable {
     final Integer id;
     final String name;
 
@@ -14,6 +16,14 @@ public final class UserD {
     }
 
     public String name() {
+        return name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
         return name;
     }
 }

--- a/__test/src/test/java/features/HttpParam4Test.java
+++ b/__test/src/test/java/features/HttpParam4Test.java
@@ -143,7 +143,8 @@ public class HttpParam4Test extends HttpTester {
         oNode.set("id", "1")
                 .set("name", "noear")
                 .set("icon", "bbb")
-                .set("date", "2021-12-12 12:12:12");
+                .set("date", "2021-12-12");
+
 
         //走param，@Param 的格式化会起效果
         String json2 = path("/demo2/param4/param3").bodyJson(oNode.toJson()).post();

--- a/__test/src/test/java/features/HttpParam4Test.java
+++ b/__test/src/test/java/features/HttpParam4Test.java
@@ -233,11 +233,12 @@ public class HttpParam4Test extends HttpTester {
 
     @Test
     public void test() throws IOException {
-        String body = "hello";
+        String body = "'hello'";
 
         //paramMap()->body()
         System.out.println(body);
         String body2 = path("/demo2/param4/test").bodyJson(body).post();
+        System.out.println(body2);
 
         assert body.equals(body2);
     }

--- a/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonDecoder.java
+++ b/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonDecoder.java
@@ -32,7 +32,7 @@ public class JacksonDecoder implements Decoder {
         mapper_type.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         mapper_type.activateDefaultTypingAsProperty(
                 mapper_type.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, "@type");
+                ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT, "@type");
         mapper_type.registerModule(new JavaTimeModule());
         // 允许使用未带引号的字段名
         mapper_type.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);

--- a/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonDecoder.java
+++ b/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonDecoder.java
@@ -2,6 +2,7 @@ package org.noear.nami.coder.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -33,6 +34,10 @@ public class JacksonDecoder implements Decoder {
                 mapper_type.getPolymorphicTypeValidator(),
                 ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, "@type");
         mapper_type.registerModule(new JavaTimeModule());
+        // 允许使用未带引号的字段名
+        mapper_type.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        // 允许使用单引号
+        mapper_type.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
     }
 
     @Override

--- a/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonEncoder.java
+++ b/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonEncoder.java
@@ -1,5 +1,6 @@
 package org.noear.nami.coder.jackson;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -18,7 +19,14 @@ public class JacksonEncoder implements Encoder {
 
     public JacksonEncoder() {
         mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.activateDefaultTypingAsProperty(
+                mapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT, "@type");
         mapper.registerModule(new JavaTimeModule());
+        // 允许使用未带引号的字段名
+        mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        // 允许使用单引号
+        mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
     }
 
     @Override

--- a/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonEncoder.java
+++ b/_nami/nami.coder.jackson/src/main/java/org/noear/nami/coder/jackson/JacksonEncoder.java
@@ -19,9 +19,6 @@ public class JacksonEncoder implements Encoder {
 
     public JacksonEncoder() {
         mapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        mapper.activateDefaultTypingAsProperty(
-                mapper.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT, "@type");
         mapper.registerModule(new JavaTimeModule());
         // 允许使用未带引号的字段名
         mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);

--- a/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonActionExecutor.java
+++ b/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonActionExecutor.java
@@ -2,7 +2,9 @@ package org.noear.solon.serialization.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.noear.solon.Utils;
 import org.noear.solon.core.handle.ActionExecutorDefault;
 import org.noear.solon.core.handle.Context;
@@ -31,6 +33,12 @@ public class JacksonActionExecutor extends ActionExecutorDefault {
         mapper_type.activateDefaultTypingAsProperty(
                 mapper_type.getPolymorphicTypeValidator(),
                 ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, "@type");
+        // 注册 JavaTimeModule ，以适配 java.time 下的时间类型
+        mapper_type.registerModule(new JavaTimeModule());
+        // 允许使用未带引号的字段名
+        mapper_type.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        // 允许使用单引号
+        mapper_type.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
     }
 
     @Override

--- a/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonActionExecutor.java
+++ b/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonActionExecutor.java
@@ -32,7 +32,7 @@ public class JacksonActionExecutor extends ActionExecutorDefault {
         mapper_type.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         mapper_type.activateDefaultTypingAsProperty(
                 mapper_type.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, "@type");
+                ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT, "@type");
         // 注册 JavaTimeModule ，以适配 java.time 下的时间类型
         mapper_type.registerModule(new JavaTimeModule());
         // 允许使用未带引号的字段名

--- a/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonRenderFactory.java
+++ b/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonRenderFactory.java
@@ -1,5 +1,6 @@
 package org.noear.solon.serialization.jackson;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -19,6 +20,10 @@ public class JacksonRenderFactory extends JacksonRenderFactoryBase {
     public JacksonRenderFactory(){
         config.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         config.registerModule(new JavaTimeModule());
+        // 允许使用未带引号的字段名
+        config.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        // 允许使用单引号
+        config.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
     }
 
 

--- a/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonRenderTypedFactory.java
+++ b/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonRenderTypedFactory.java
@@ -25,7 +25,7 @@ public class JacksonRenderTypedFactory extends JacksonRenderFactoryBase {
         config.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         config.activateDefaultTypingAsProperty(
                 config.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, "@type");
+                ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT, "@type");
         config.registerModule(new JavaTimeModule());
         // 允许使用未带引号的字段名
         config.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);

--- a/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonRenderTypedFactory.java
+++ b/_solon_base_render/solon.serialization.jackson/src/main/java/org/noear/solon/serialization/jackson/JacksonRenderTypedFactory.java
@@ -2,6 +2,7 @@ package org.noear.solon.serialization.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -26,6 +27,10 @@ public class JacksonRenderTypedFactory extends JacksonRenderFactoryBase {
                 config.getPolymorphicTypeValidator(),
                 ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, "@type");
         config.registerModule(new JavaTimeModule());
+        // 允许使用未带引号的字段名
+        config.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        // 允许使用单引号
+        config.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
     }
 
     @Override


### PR DESCRIPTION
主要修改 ObjectMapper 配置，增加一下两点兼容：

1. 允许使用未带引号的字段名
2. 允许使用单引号