### PR TITLE
update s3 file used.

### DIFF
--- a/solon-projects/solon-plugin-cloud/aws-s3-solon-cloud-plugin/README.md
+++ b/solon-projects/solon-plugin-cloud/aws-s3-solon-cloud-plugin/README.md
@@ -24,3 +24,12 @@ solon.cloud.aws.s3:
     accessKey: 'xxxx'
     secretKey: 'xxx'  
 ```
+
+If not provided accessKey and secretKey, then use aws default credentials provided. 
+you need run on AWS services and use AWS IAM authentications.
+
+```yaml
+solon.cloud.aws.s3:
+  file:
+    enable: true                  #是否启用（默认：启用）
+```

--- a/solon-projects/solon-plugin-cloud/aws-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/aws/s3/XPluginImp.java
+++ b/solon-projects/solon-plugin-cloud/aws-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/aws/s3/XPluginImp.java
@@ -21,9 +21,10 @@ public class XPluginImp implements Plugin {
         CloudProps cloudProps = new CloudProps(context, "aws.s3");
 
         if (cloudProps.getFileEnable()) {
-            if (Utils.isEmpty(cloudProps.getFileAccessKey())) {
-                return;
-            }
+            // maybe we should use AWS environment
+//            if (Utils.isEmpty(cloudProps.getFileAccessKey())) {
+//                return;
+//            }
 
             if (ClassUtil.loadClass(AWS_SDK_TAG) == null) {
                 CloudManager.register(new CloudFileServiceOfS3HttpImpl(cloudProps));

--- a/solon-projects/solon-plugin-cloud/aws-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/aws/s3/utils/BucketUtils.java
+++ b/solon-projects/solon-plugin-cloud/aws-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/aws/s3/utils/BucketUtils.java
@@ -7,6 +7,8 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -37,11 +39,15 @@ public class BucketUtils {
         String accessKey = cloudProps.getFileAccessKey();
         String secretKey = cloudProps.getFileSecretKey();
 
-        if (Utils.isEmpty(regionId) && Utils.isEmpty(endpoint)) {
-            throw new CloudFileException("The 'regionId' and 'endpoint' configuration must have one");
+//        if (Utils.isEmpty(regionId) && Utils.isEmpty(endpoint)) {
+//            throw new CloudFileException("The 'regionId' and 'endpoint' configuration must have one");
+//        }
+        if (Utils.isNotBlank(accessKey) && Utils.isNotBlank(secretKey)) {
+            return createClient(endpoint, regionId, accessKey, secretKey, cloudProps.getProp("file"));
         }
 
-        return createClient(endpoint, regionId, accessKey, secretKey, cloudProps.getProp("file"));
+        //use aws default credentials provider
+        return AmazonS3ClientBuilder.defaultClient();
     }
 
     public static AmazonS3 createClient(String endpoint, String regionId, String accessKey, String secretKey, Properties props) {

--- a/solon-projects/solon-plugin-cloud/file-s3-solon-cloud-plugin/README.md
+++ b/solon-projects/solon-plugin-cloud/file-s3-solon-cloud-plugin/README.md
@@ -19,6 +19,9 @@ solon.cloud.file.s3.file:
       
 ```
 
+If not provided accessKey and secretKey, then use aws default credentials provided. 
+you need run on AWS services and use AWS IAM authentications.
+
 其它 s3 bucket 属性支持
 ```yml
 demo1_bucket:

--- a/solon-projects/solon-plugin-cloud/file-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/file/s3/service/CloudFileServiceImpl.java
+++ b/solon-projects/solon-plugin-cloud/file-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/file/s3/service/CloudFileServiceImpl.java
@@ -49,6 +49,7 @@ public class CloudFileServiceImpl implements CloudFileService {
     public void addBucket(String bucketName, Props props){
         String endpoint = props.getProperty("endpoint");
 
+        // TODO!!!
         if (Utils.isNotEmpty(endpoint)) {
             if (endpoint.startsWith("http://") || endpoint.startsWith("https://") || endpoint.contains("/") == false) {
                 bucketServiceMap.put(bucketName, new CloudFileServiceOfS3SdkImpl(bucketName, props));

--- a/solon-projects/solon-plugin-cloud/file-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/file/s3/utils/BucketUtils.java
+++ b/solon-projects/solon-plugin-cloud/file-s3-solon-cloud-plugin/src/main/java/org/noear/solon/cloud/extend/file/s3/utils/BucketUtils.java
@@ -36,19 +36,23 @@ public class BucketUtils {
         String accessKey = props.getProperty("accessKey");
         String secretKey = props.getProperty("secretKey");
 
-        if(accessKey == null){
+        if (accessKey == null) {
             accessKey = props.getProperty("username");
         }
 
-        if(secretKey == null){
+        if (secretKey == null) {
             secretKey = props.getProperty("password");
         }
 
-        if (Utils.isEmpty(regionId) && Utils.isEmpty(endpoint)) {
-            throw new CloudFileException("The 'regionId' and 'endpoint' configuration must have one");
+//        if (Utils.isEmpty(regionId) && Utils.isEmpty(endpoint)) {
+//            throw new CloudFileException("The 'regionId' and 'endpoint' configuration must have one");
+//        }
+        if (Utils.isNotBlank(accessKey) && Utils.isNotBlank(secretKey)) {
+            return createClient(endpoint, regionId, accessKey, secretKey, props);
         }
 
-        return createClient(endpoint, regionId, accessKey, secretKey, props);
+        //use aws default credentials provider
+        return AmazonS3ClientBuilder.defaultClient();
     }
 
     public static AmazonS3 createClient(String endpoint, String regionId, String accessKey, String secretKey, Properties props) {


### PR DESCRIPTION
What's been added?
If not provided accessKey and secretKey, then use aws default credentials provided. 
you need run on AWS services and use AWS IAM authentications.

How to use it?

remove config file filed, access key, secret key and region id and endpoint. if you run on aws.

中文版


添加了什么？
如果你没有提供accessKey 和 secretKey,那么使用aws默认提供的认证链去匹配认证。
你必须运行在aws环境。

如何使用？
删除掉配置字段， access key, secret key, region id, endpoint. 如果你运行在aws环境。