### PR TITLE
chore(admin): add default properties

### DIFF
--- a/solon-projects/solon-tool/solon-admin-client/src/main/java/org/noear/solon/admin/client/config/CloudClientProperties.java
+++ b/solon-projects/solon-tool/solon-admin-client/src/main/java/org/noear/solon/admin/client/config/CloudClientProperties.java
@@ -9,7 +9,7 @@ public class CloudClientProperties implements IClientProperties {
 
     private String mode = "cloud";
 
-    private String serverUrl;
+    private String serverUrl = "http://localhost:8080";
 
     private long heartbeatInterval = 10 * 1000;
 

--- a/solon-projects/solon-tool/solon-admin-client/src/main/java/org/noear/solon/admin/client/config/LocalClientProperties.java
+++ b/solon-projects/solon-tool/solon-admin-client/src/main/java/org/noear/solon/admin/client/config/LocalClientProperties.java
@@ -9,7 +9,7 @@ public class LocalClientProperties implements IClientProperties {
 
     private String mode = "local";
 
-    private String serverUrl;
+    private String serverUrl = "http://localhost:8080";
 
     private long heartbeatInterval = 10 * 1000;
 

--- a/solon-projects/solon-tool/solon-admin-server/src/main/java/org/noear/solon/admin/server/config/ServerProperties.java
+++ b/solon-projects/solon-tool/solon-admin-server/src/main/java/org/noear/solon/admin/server/config/ServerProperties.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import org.noear.solon.annotation.Configuration;
 import org.noear.solon.annotation.Inject;
 
-@Inject("${solon.admin.server}")
+@Inject(value = "${solon.admin.server}", required = false)
 @Configuration
 @Data
 public class ServerProperties {


### PR DESCRIPTION
- fix(solon-admin:server-ui): wrong usage of slot
- fix(solon-admin:server-ui): wrong layout when slot empty
- fix(solon-admin:server-ui): fix several typescript error
- feat(solon-admin:server-ui): empty project dashboard
- feat(solon-admin:client): properties loading
- feat(solon-admin:server): properties loading
- feat(solon-admin): update group id
- feat(solon-admin): add solon-logging-simple
- fix(solon-admin): fix several injection and condition bugs
- refactor(solon-admin): remove duplicated properties
- refactor(solon-admin:client): refactor client properties
- feature(solon-admin:server): add cloud support
- fix(solon-admin:server): mismatch dependency groupId
- fix(solon-admin): add test
- feat(solon-admin): add application registration
- refactor(solon-admin): fix deprecated maven properties
- feat(solon-admin:server-ui): add vueuse
- feat(solon-admin): add enable log
- fix(solon-admin:server-ui): fix esm-bundler warn for vue-i18n
- chore(solon-admin:server-ui): update to vue3.3
- feat(solon-admin:client): add log for application registration and de-registration
- feat(solon-admin:client): catch unexpected error in application registration
- feat(solon-admin:client): disallow duplicated locale change
- feat(solon-admin): application service
- refactor(solon-admin): useApplication hook
- feat(solon-admin): update application list by polling
- feat(solon-admin): unregister application
- just finish coding...
- 2.2.21-SNAPSHOT
- refactor(solon-admin-server-ui): refactor useApplications
- feat(solon-admin): add getApplication
- refactor(solon-admin): refactor router
- refactor(solon-admin): move sidebar slot to router view
- refactor(solon-admin): ui improvement
- add `isNotAotRuntime`
- finish simple unit test
- 新增 etcd-solon-cloud-plugin 插件
- 添加 ProxyUtil::attach(ctx,clz,obj,handler) 接口
- 添加一个 demo
- 新增 solon.web.servlet.jakarta 插件
- 完善单测用例
- mybatis-flex 升为 1.2.6
- 2.3.0-SNAPSHOT
- 弃用 `@Dao` `@Repository` `@Service` （改由 `@ProxyComponent` 替代）
- 新增 zipkin-solon-cloud-plugin 插件？？？
- 添加注释
- 增加 aot 对 methodWrap 参数的自动登记处理
- 增加zipkin-solon-cloud-plugin模块
- 升级 slf4j 升为 2.x
- 新增 fastmybatis-solon-plugin 插件
- 新增 zipkin-solon-cloud-plugin 插件
- 调整 日志体系升到 slf4j 2.x
- 调整 mybatis 按包名扫描只对 `@Mapper` 注解的接口有效
- logback 升为 1.3.7（基于 slf4j 2.x）
- sqltoy 升为  5.2.48
- 新增 etcd-solon-cloud-plugin 插件
- 新增 etcd-solon-cloud-plugin 插件
- 修复 AopContext::getWrapsOfType 返回结果失真的问题
- 新增 solon.docs 插件
- 新增 solon-swagger-knife4j 插件
- 新增 solon-swagger-knife4j 插件
- 新增 solon.docs 插件
- 新增 solon-swagger2-knife4j 插件
- 新增 solon.docs 插件
- 新增 solon.docs 插件!!!
- 新增 solon.docs 插件!!!
- 新增 solon.docs 插件!!!
- 完善 solon-swagger2-knife4j 插件
- 完善 solon-swagger2-knife4j 插件
- Update README.md
- Update README.md
- EnableSwagger2 更名为 EnableDoc
- EnableSwagger2 更名为 EnableDoc
- EnableSwagger2 更名为 EnableDoc
- EnableSwagger2 更名为 EnableDoc
- 完善 solon-swagger2-knife4j 插件
- 完善 solon-swagger2-knife4j 插件
- 完善 solon-swagger2-knife4j 插件
- Update app.yml
- 完善 solon.docs 插件
- 完善 solon.docs 插件
- 升级一些框架版本
- 成化 solon.docs 对泛型响应结果的处理
- 优化 solon.docs 对无注解参数的处理
- 优化 solon.docs 对签权的处理
- 优化 solon.docs 请求参数的处理
- 优化 solon.docs 注释
- 添加 solon.docs 的模型结构
- 2.3.0
- 2.3.1-SNAPSHOT
- 2.3.1-SNAPSHOT
- 调整 enableDoc 的控制顺序
- 调整 enableDoc 的控制顺序
- 调整目录结构
- Update pom.xml
- 调整目录结构
- Update CONTRIBUTING.md
- 调整目录结构
- 删除apt相关包
- 调整目录结构
- Revert "删除apt相关包"
- sqltoy 升为 5.2.51
- 日志依赖引用调整
- feat(插件适配): shardingSphere插件适配，适配官方yml配置
- 调整依赖版本结构
- 优化 solon.config.yaml 增加类型映射解析支持（将 "!XXX: xxx" 转为普通属性）
- 调整 shardingsphere-solon-plugin 的配置机制
- 新增 shardingsphere-solon-plugin 插件
- feat(插件适配): README.md 文档完善，添加测试代码。
- 调整注释
- 调整 shardingsphere-solon-plugin 的适配风格
- 新增 redisson-solon-plugin 插件
- feat(插件适配): redisson 插件适配 & 升级redisson版本到3.21.0 & 文档完善，添加测试代码。
- 调整 redisson-solon-plugin 适配
- 调整 shardingsphere-solon-plugin 适配
- redisson 升为 3.21.0
- 调整 solon-swagger2-knife4j 插件的优先级，以便控制 enableDoc
- 新增 solon.data.shardingds 插件
- 新增 solon.data.shardingds 插件
- shardingsphere-solon-plugin 更名为 solon.data.shardingds （提高了级别）
- XxxCacheService 增加新的构造函数
- fastjson2 升为 2.0.33
- 删除测试代码。移到官网示例
- 排除闻分 slf4j-api 依赖
- weixin 相关插件移除对 spring-data 的依赖
- weixin 相关插件移除对 spring-data 的依赖
- 移除 sms4j-solon-plugin 的实现代码，改为包引用
- mybatis 支持 graalvm native 打包
- mybatis 适配增加 isMapper 检测接口
- 调整 mybatis aot 处理
- 开放 bean 形态注册的限制，之前只能是普通组件现在代理组件也可以
- 调整 mybatis aot 处理
- 应用时的事件改由 push 推送（之前是 pushTry）
- 调整 MybatisAdapterDefault 对 mapper 的记录
- aot 时才注册 MybatisRuntimeNativeRegistrar
- 调整 MybatisAdapterDefault 对 mapper 的记录
- mybatis-flex 升为 1.3.2
- 调整 应用启动时的事件改由 push 推送（之前是 pushTry）
- 调整 aot 对资源配置到 solon-resource.json 的处理
- 调整 aot 对资源配置到 solon-resource.json 的处理
- 调整 aot 对资源配置到 solon-resource.json 的处理
- 把配置的mapper的星号替换为.*
- 调整 jlhttp Part 的 body string 大小限制改为 MAX_BODY_SIZE（之前为 MAX_HEADER_SIZE）
- 2.3.1
- 2.3.2-SNAPSHOT
- Update repository.xml
- 2.3.2-SNAPSHOT
- Create group_qq.png
- Create group_wx.png
- Update README.md
- Update pom.xml
- 调整 loadClass 的异常处理
- 调整 newinstance(clz) 的异常处理
- Update solon_schema.png
- 调整 newinstance(str) 更名为 tryInstance(str) //旧的标为弃用
- mybatis 增加 mapperVerifyEnabled 配置（用于控制是否强制检测）
- 优化 swagger 处理，非"@Body"的实体进行字段分解处理
- 2.3.2
- Update pom.xml
- 2.3.2
- 2.3.3-SNAPSHOT
- refactor(solon-admin): use websocket to fetch applications instead of long polling
- fix(solon-admin:server): duplicated application registration
- fix(solon-admin:server-ui): wrong usage of slot
- fix(solon-admin:server-ui): wrong layout when slot empty
- fix(solon-admin:server-ui): fix several typescript error
- feat(solon-admin:server-ui): empty project dashboard
- feat(solon-admin:client): properties loading
- feat(solon-admin:server): properties loading
- feat(solon-admin): update group id
- feat(solon-admin): add solon-logging-simple
- fix(solon-admin): fix several injection and condition bugs
- refactor(solon-admin): remove duplicated properties
- refactor(solon-admin:client): refactor client properties
- feature(solon-admin:server): add cloud support
- fix(solon-admin:server): mismatch dependency groupId
- fix(solon-admin): add test
- feat(solon-admin): add application registration
- refactor(solon-admin): fix deprecated maven properties
- feat(solon-admin:server-ui): add vueuse
- feat(solon-admin): add enable log
- fix(solon-admin:server-ui): fix esm-bundler warn for vue-i18n
- chore(solon-admin:server-ui): update to vue3.3
- feat(solon-admin:client): add log for application registration and de-registration
- feat(solon-admin:client): catch unexpected error in application registration
- feat(solon-admin:client): disallow duplicated locale change
- feat(solon-admin): application service
- refactor(solon-admin): useApplication hook
- feat(solon-admin): update application list by polling
- feat(solon-admin): unregister application
- refactor(solon-admin-server-ui): refactor useApplications
- feat(solon-admin): add getApplication
- refactor(solon-admin): refactor router
- refactor(solon-admin): move sidebar slot to router view
- refactor(solon-admin): ui improvement
- refactor(solon-admin): use websocket to fetch applications instead of long polling
- fix(solon-admin:server): duplicated application registration
- sync(solon-admin): sync upstream dir changes
- sync(solon-admin): sync upstream
- 调整 solon-cloud-alibaba 快捷包 改用 nacos2,rocketmq5
- dubbo3 升为 3.2.2
- refactor(solon-admin:server): remove unnecessary code
- 调整 file-s3-solon-cloud-plugin 插件，不排除 aws-java-sdk-s3（之前为排除）
- 添加 solon.web.sse 模块
- 添加 solon.web.sse 模块
- refactor(solon-admin:server): remove unused import
- refactor(solon-admin:server-ui): resolve some strange things
- refactor(solon-admin:server-ui): refactor
- 添加 dromara-plugins 所有插件的版本管理
- 优化 Context::filesMap() 改抛 IOException 异常
- 添加 PathRule 工具类
- 添加 RouterRuleInterceptor 路由规则拦截器
- 添加 RouterRuleInterceptor 带路径规则的路由拦截器
- 添加 RouterRuleInterceptor 带路径规则的路由拦截器
- 简化 Context::param(key,def) 处理
- 增加注释
- 添加 PathLimiter 用于限制 Filter 和 RouterInterceptor 的范围
- 添加 PathLimiter 用于限制 Filter 和 RouterInterceptor 的范围
- nacos2 升为 2.2.3
- 支持@Inject("${a:${b:3}}")形式
- 调整说明
- 添加 PathLimiter 用于限制 RouterInterceptor 的范围
- 调整 Classutil 异常处理
- 调整 Classutil 异常处理
- 添加 PathLimiter 用于限制 RouterInterceptor 的范围
- 添加 PathLimiter 用于限制 RouterInterceptor 的范围
- 添加 PathLimiter 用于限制 RouterInterceptor 的范围
- 增加 @Param 别名单测
- 调整 ClassUtil 的异常处理
- add sse support
- add sse support
- 调整 AopContext::findConfigKey 的判断顺序
- 添加 MybaitsAdapter::getMapper 增加缓存处理
- 优化 AsmProxy 代理类的缓存机制（简化）
- 添加新的模块
- update solon/src/main/java/org/noear/solon/Utils.java.
- update s3 file used.
- 优化无 accessKey 和 secretKey 的使用处理（保持与其它 cloud file 插件共存的兼容）
- 添加 maxHeaderSize(8k), maxBodySize(2m) 为 server 统一默认配置，不然会出 readToken 错误
- 添加 Context::sessionOrDefault(),headerOrDefault(),paramOrDefault() 接口
- 添加 ChainManager::getFilterNodes(),getInterceptorNodes() 接口
- 2.3.3
- Update .editorconfig
- Delete solon.png
- Create solon.png
- Delete Solon-启动处理顺序.md
- 2.3.4-SNAPSHOT
- 2.3.4-SNAPSHOT
- 2.3.4-SNAPSHOT
- refactor(solon-admin): code refactor
- graalvm native 增加lambda序列化
- 完善 mybatis native
- 支持 mybatis-plus native
- 添加网关 path var 单测
- 修复请求路径动态变化后，路径变量获取失败的问题
- 调整单测 “test-serialization-config” 资源配置
- 调整 sse 实现
- 完善 sse 实现
- 配置注入默认值支持集合类型
- guava 升为 32.0.0-jre
- 重试注解和重试工具类添加
- smarthttp 升为 1.2.3
- 微调 retry 实现
- 添加配置注入单测
- 调整 sse 实现。增加 keepAlive
- 增加 Inject("{xxx:def}}") 默认值转集合和数组支持
- 调整 Retry 实现细节
- 增加 solon.scheduling 插件 简单的 Retry 功能
- smarthttp 升为 1.2.4
- 完善 retry 兜底接口
- hutool 升为 5.8.20
- 增加 sse 异步实现
- fastjson2 升为 2.0.34
- 增加 jetty、undertow 对 Context 异步适配
- 新增 solon.web.reactor 插件（适用于支持异步的 http server）
- 插件 solon.web.reactor 更名为 solon.web.flux
- 增加 solon.docs 插件，支持字段 transient 排除
- dromara-plugins 升为 0.0.9
- forest 升为 1.5.32
- 增加 ActionExecuteHandler 接口（替代旧的 ActionExecutor），并交由 chainManager 管理
- 完善 sse 实现
- 完成简单的异步事件对接
- 添加 context 异步监听接口
- 添加 Flux 单测用例
- 优化 smart-http 异步适配
- 调整 flux 示例
- Update V2.0.md
- 完成issues：参数校验目前只能顺序校验，一个一个的校验，无法一下把所有的错误信息返回
- 完善 sse 实现代码
- 调整 sse 超时处理
- 调整 sse 超时处理
- 增加 solon.validation 一次性验证所有字段的支持
- 调整 smart-http 异步代码
- smarthttp 添加异步超时
- 2.3.4
- 2.3.4
- 2.3.5-SNAPSHOT
- 2.3.5-SNAPSHOT
- 2.3.5-SNAPSHOT
- 新增 solon.boot.websocket.netty 插件
- 尝试 solon.boot.websocket.netty 新的实现方式
- 增加新的 ws 单测
- 完成 websokcet-netty 插件
- 优化 solon.boot.websocket.netty
- 优化 ws 无效链接处理
- 调整 solon.boot.jdkhttp 插件，增加虚拟异步支持（进而支持响应式接口）
- 调整 solon.boot.jlhttp 插件，增加虚拟异步支持（进而支持响应式接口）
- 异步接口机制，只能启动一次
- 调整 Context 异步接口机制
- 调整 solon.web.sse 插件，改为纯异步机制（所有 solon.boot.http 已支持异步）
- 调整 flux ，出错时直接结束异常
- 调整 Context 异步接口机制
- 优化 Servlet Context 异步接口机制
- 优化 SmartHttp Context 异步接口机制
- 优化 JdkHttp Context 异步接口机制
- 优化 SmartHttp Context 异步接口机制
- 优化 Servlet 启动打印信息
- 优化 Servlet Context 异步接口机制
- 内部函数 Context:commit 更名为 innertCommit
- jlhttp 增加流刷新输出支持
- 优化 jlhttp 补尝状态处理
- 优化 SmartHttp Context 异步接口机制
- 优化 Context 异步接口异常类型
- 调整非异步的异常提示
- update solon/src/main/java/org/noear/solon/core/JarClassLoader.java 补全扩展类名： AppClassLoaderEx --> AppClassLoaderExt
- 修复 pathNew 多次执行后 ContextPathFilter 会失效的问题
- 优化 ContextPathFilter 对根地址的映射处理
- 取消 Component 注解加到别的注解上
- 2.3.5
- 2.3.6-SNAPSHOT
- Delete solon_schema.png
- Add files via upload
- 修复异步监听可能为null的问题
- 2.3.6
- 2.3.7-SNAPSHOT
- 添加 solon.boot.vertx 模块
- 修复在win系统情况下 无法注入本地存储的问题
- wood 升为 1.1.5
- 添加 solon.cloud.metrics 模块
- 优化 nami 解码器的渲染要求策略
- 调整 solon.boot.websocket 异步发送机制
- 调整 solon.boot.websocket.netty 异步发送机制
- 优化 nami 解码器的渲染要求策略
- 增加 ssl 证书专用配置接口
- 增加 ssl 证书专用配置接口
- 增加 server.http.ssl.* 配置
- 增加 NamiMapping、NamiBody 注解
- Update UPDATE_LOG.md
- 指定线程池的前缀名称 CompletableFuture.runAsync显式指定线程池
- smarthttp 升为 1.2.6
- 增加 CloudEvent 注解在函数上时，支持 AOP 扩展
- 调整 RunUtil 增加线程池名
- 调整 StringSerializerRender 开放 serializer 属性
- 修复 solon.serialization.jackson 在某些情况下，序列化 null 会出错的问题
- 增加 Context::headersMap 接口
- 增加 solon.boot.socketd.jdksocket 插件对 ssl 的支持
- 调整 app.router().caseSensitive 默认为 true
- 增加 swagger2 对网关开发模式的支持
- Update UPDATE_LOG.md
- 添加 headersMap 单测
- 修复 solon.boot.jetty 不能使用资源文件做 ssl 密钥文件的问题
- refactor(solon-admin): vue 3.3.4
- feature(solon-admin:server-ui): sidebar implementation
- 2.3.7
- 2.3.8-SNAPSHOT
- 调整测试模块目录结构
- 增加 HttpServerConfigure::enableHttp2 接口, 默认为 false
- 调整 solon.view.* 增加引擎提供者获取属性
- 调整 单元测试项目结构
- feature(solon-admin:server-ui): info, health and metadata ui in details
- feature(solon-admin): environment
- 增加 HttpServerConfigure::enableHttp2 接口, 默认为 false
- 简化两处代码
- sqltoy 升级到5.2.57,增加LightDao的支持，升级部分自定义配置的支持。该版本目前对自定义任务池配置只支持通过service名字指定任务池，不支持自动初始化任务池。
- 优化 sqltoy 适配代码，增加LightDao的支持
- 优化 hasor-solon-plugin 插件适配，支持最新状态
- 调整 mqtt-solon-cloud-plugin 插件，增加获取原生 client 接口
- 调整 IpUtil 增加扩展 ip 实现
- sqltoy 升为 5.2.58
- 调整 solon.docs 插件，在无参 post 时，不再自动转成 get
- 调整 solon.docs 插件，在无参 post 时，不再自动转成 get；增加 @Api::value() 做为 tags
- mybatis-flex 升为 1.4.7
- 调整 Gateway:register 执行时机为容器启动时，使注册时可使用注入字段
- 调整 solon.boot.undertow 在客户端进程半闭时触发 onClose 事件
- 增加 UploadedFile[] 注入支持
- minio 降为 8.2.2
- 修复 solon.boot.smarthttp 在客户端进程关闭时，不能触发 onClose 事件的问题
- 调整几个 maven 版本依赖关系
- 2.3.8
- 2.3.9-SNAPSHOT
- 增加提到 MqttClient 的 demo
- 调整 nacos2 适配的 jackson 版本
- feature(solon-admin): monitor
- 新增 solon-admin
- 调整包依赖
- 调整包依赖
- 添加插件集成配置（否则，别的项目扫描不到 MonitorController）
- 添加 smarthttp ，用于支持 ws
- 取消对 transient 的过滤
- 增加 Context::isSecure 接口
- 调整 LogUtil 改成静态扩展方式，原手动设置标为弃用
- 调整 nacos-solon-cloud-plugin 适配的  jackson 版本
- dbvisitor 升为 5.3.3
- 调整单测项目描述
- 调整 Context::headerValues() 返回类型为 String[]；调整 Context::paramValues() 所有 server 相关处理逻辑
- 增加 ChainManager::defExecuteHandler 接口
- 添加个研究示例
- frontend-maven-plugin 升为 1.13.4
- 增强 ResourceUtil 的根路径兼容性
- 调整 @Init 注解逻辑，仅对原生实例有效。保持与 LifecycleBean 相同策略
- 调整 solon.boot.smarthttp 的 ws 适配
- beetlsql 升为 3.23.4-RELEASE
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- update actions.
- 优化 统一 请求参数与实体字段的注入转换机制
- 2.4.0-SNAPSHOT
- 增加 Converter 体系，一般用于基础类型的通用转换
- 添加 Converter 体系的单测
- mybatis-flex 升为 1.5.0
- 调整 readme
- VarDeclarer 更名为 VarDescriptor
- 调整注释
- 优化 JsonConverter 标为弃用，统一由 Converter 替代
- 优化 内核日志打印顺序，由 SolonApp 实例化后再打印。以便日志配置先加载
- 优化 LogUtil 扩展方式，改为静态扩展方式，原手方式标为弃用
- test actions.
- 调整 RunUtil 线程名
- test actions.
- action remove reporter.
- action remove reporter.
- 增加 日志服务孵化机制，可在打印前进行完成格式配置
- 优化 内核日志打印顺序，由 SolonApp 实例化后再打印。以便日志格式配置先加载
- 优化 ActionExecuteHandlerDefault::changeBody 参数结构，方便 Protostuff 处理
- 优化 Nami 编码器匹配策略，尤其是仅单编码包引入时
- 优化 Nami 编码器匹配策略，尤其是仅单编码包引入时
- Update UPDATE_LOG.md
- 优化 SocketChannelBase 标为弃用，统一由 ChannelBase 替代
- 增加 ChainManager 对 SessionStateFactory 的管理，原管理方式移除
- smarthttp 升为 1.2.8
- 增加 solon.socketd.client.netty 插件对 ssl 的支持
- 增加 solon.boot.websocket.netty 插件对 ssl 的支持
- 增加 solon.boot.socketd.netty 插件对 ssl 的支持
- 优化 RouterListener 取消自己的线程池，改用 RunUtil
- 优化 ShardingDataSource 增加 Closeable 接口支持
- 优化 AbstractRoutingDataSource 的关闭处理
- 调整包管理结构
- 优化 solon.boot.smarthttp 的 ws 适配
- 修复 solon-swagger2-knife4j 插件，递归类型的数据模型会栈溢出的问题
- 调整 maven 模块结构
- 调整 beetlsql-solon-plugin 插件，DbConnectionSource 改为公有，调整包结构
- 增加 Closeable 传递
- mybatis-flex 升为 1.5.1
- __hatch
- 修复 solon-swagger2-knife4j 插件，相同 path 不能显示多个 method 的问题
- 修复 solon-swagger2-knife4j 插件，`List<Demo>` 风格参数，不能正常构建 json 示例
- 新增 solon-openapi2-knife4j 插件，替代 solon-swagger2-knife4j
- fastjson2 升为 2.0.35
- 修复 solon-swagger2-knife4j 插件，`Page<Demo>` 风格的临时模型，不能正常构建 json 示例
- 修复 solon-swagger2-knife4j 插件，`Page<Demo>`、`Result<Page<Demo>>` 等复杂嵌套的临时模型，不能正常构建 json 示例
- 优化 当使用 http ssl 时，服务启动打印为 https 地址
- 2.4.0
- 2.4.0
- 2.4.1-SNAPSHOT
- 2.4.1-SNAPSHOT
- 新增 solon.web.servlet.jakarta 插件
- 简化 Db 使用（去掉包名）
- 优化 solon.boot 信号启动的执行时机后延
- 优化 solon.scheduling 插件的 retry 的兜底设计
- 调整 AopContext::beanAroundXxx 标为弃用，添加 beanInterceptorXxx 代之
- 调整 Around 相关名改为 Interceptor，原名标为弃用
- 优化 EventBus 增加订阅排序支持
- 调整 EventBus::push 标为弃用，添加 ::publish 代之
- 调整事件总线相关注释
- 修复 bean 所有字段只读且无 public 构造器时，会异常的问题
- 调整 ProxyComponent 注解属性调整成与 Component 注解一样
- wood 升为 1.1.6
- 动态代理添加更多不支持的类型检测
- wood 升为 1.1.7
- chore(admin): add default properties
