### PR TITLE
增加给所有controller开启效验的配置项

### DIFF
--- a/solon-projects/solon-base/solon.validation/README.md
+++ b/solon-projects/solon-base/solon.validation/README.md
@@ -3,4 +3,6 @@
 
 ```yaml
 solon.validation.validateAll: false #true
+
+solon.validation.allControllerValidation: true # 开启自动给所有controller开启效验
 ```

--- a/solon-projects/solon-base/solon.validation/src/main/java/org/noear/solon/validation/XPluginImp.java
+++ b/solon-projects/solon-base/solon.validation/src/main/java/org/noear/solon/validation/XPluginImp.java
@@ -1,6 +1,7 @@
 package org.noear.solon.validation;
 
 import org.noear.solon.Solon;
+import org.noear.solon.annotation.Controller;
 import org.noear.solon.core.AppContext;
 import org.noear.solon.core.Plugin;
 import org.noear.solon.validation.annotation.*;
@@ -14,7 +15,14 @@ public class XPluginImp implements Plugin {
     public void start(AppContext context) {
         ValidatorManager.VALIDATE_ALL = Solon.cfg().getBool("solon.validation.validateAll", false);
 
-        context.beanInterceptorAdd(Valid.class, new BeanValidateInterceptor(), 1);
+        boolean allControllerValidation = Solon.cfg().getBool("solon.validation.allControllerValidation", false);
+
+        if(allControllerValidation){
+            // 给所有controller开启效验
+            context.beanInterceptorAdd(Controller.class, new BeanValidateInterceptor(), 1);
+        }else{
+            context.beanInterceptorAdd(Valid.class, new BeanValidateInterceptor(), 1);
+        }
 
         //ValidatorFailureHandler
         context.getBeanAsync(ValidatorFailureHandler.class, (bean) -> {


### PR DESCRIPTION
关于  https://gitee.com/noear/solon/issues/I98A2U  的实现
直接新增一个配置项：solon.validation.allControllerValidation 
默认为false 为true时直接给所有controller增加拦截器，为false则依旧只给有@valid的controller生效
