### PR TITLE
 修复 solon 运行目录如果存在中文，会导致无法加载外部配置文件的问题【Issue 337】

### DIFF
--- a/__test/src/test/java/features/Issue337Test.java
+++ b/__test/src/test/java/features/Issue337Test.java
@@ -1,0 +1,20 @@
+package features;
+
+import org.junit.jupiter.api.Test;
+import org.noear.solon.Utils;
+import org.noear.solon.test.SolonTest;
+import org.noear.solon.Solon;
+import webapp.App;
+
+@SolonTest(App.class)
+public class Issue337Test {
+    @Test
+    public void testFolderLocation() {
+        try {
+            String appFolder = Utils.appFolder();
+            System.out.println("文件路径: " + appFolder);
+        } catch (Throwable e) {
+            e.printStackTrace();  
+        }
+    }
+}

--- a/solon/src/main/java/org/noear/solon/Utils.java
+++ b/solon/src/main/java/org/noear/solon/Utils.java
@@ -28,6 +28,7 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.*;
 import java.util.concurrent.Future;
@@ -628,7 +629,16 @@ public class Utils {
         if (_appFolder == null) {
             _appFolder = new AtomicReference<>();
 
-            String uri = Solon.location().getPath();
+            // 修复 solon 运行目录如果存在中文，会导致无法加载外部配置文件的问题【Issue 337】
+            String encodedUri = Solon.location().getPath();
+            String uri;
+            try {
+                // 使用UTF-8解码路径，解决中文乱码问题，理论上UTF-8总是支持的
+                uri = URLDecoder.decode(encodedUri, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                uri = encodedUri; // 解码失败，使用原路径
+            }
+
             int endIdx;
 
             if (uri.endsWith("/classes/")) {


### PR DESCRIPTION
###  修复 solon 运行目录如果存在中文，会导致无法加载外部配置文件的问题【[Issue 337](https://github.com/opensolon/solon/issues/337)】


### 问题描述
Solon.location().getPath() 返回的路径字符串是经过 URL 编码的，如果不解码，后续的字符串操作将无法正确识别文件系统中的路径分隔符和目录名称，导致加载外部配置文件错误。
该pr将获取的路径进行了解码操作，使其回归到文件系统可识别的字符串形式。

### 测试结果
修改前：
<img width="1771" height="560" alt="80e86c9875e0bf408d2f99038cf02dd" src="https://github.com/user-attachments/assets/81a6025f-936b-4378-b886-9956a608b997" />
修改后：
<img width="1771" height="559" alt="85c3f908fd8844eda9180f513e8d68f" src="https://github.com/user-attachments/assets/510933ce-5134-49b4-a331-186133b0cbc1" />

#### 备注：您好，这是我首次提交 PR，非常期待能成功贡献代码。如果我的提交中有任何不合规范之处，恳请您指正，我会立即跟进修改。~
