### PR TITLE
修复 添加计数器简单处理配置项自引用或者交叉引用导致加载死循环问题【github issue 388】

### DIFF
--- a/solon/src/main/java/org/noear/solon/core/util/PropUtil.java
+++ b/solon/src/main/java/org/noear/solon/core/util/PropUtil.java
@@ -129,6 +129,14 @@ public class PropUtil {
      * @param useDef 是否使用默认值
      */
     public static String getByTml(Properties main, Properties target, String tml, String refKey, boolean useDef) {
+        // 调用私有实现，并传入初始深度 0
+        return getByTmlCheckDepth(main, target, tml, refKey, useDef, 0);
+    }
+
+    /**
+     * 根据模板获取配置值 (增加递归深度检查，防止死循环)
+     */
+    private static String getByTmlCheckDepth(Properties main, Properties target, String tml, String refKey, boolean useDef, int depth) {
         if (Assert.isEmpty(tml)) {
             return tml;
         }
@@ -149,6 +157,24 @@ public class PropUtil {
                 String valueExp = tml.substring(start + 2, end); //key:def
                 //支持默认值表达式 ${key:def}
                 String value = getByExp(main, target, valueExp, refKey, useDef);
+
+                //增加递归深度检测
+                if (value != null && value.contains("${")) {
+                    // 如果获取到的值本身还是一个模板，则需要递归解析
+                    int nextDepth = depth + 1;
+                    // 检查深度是否超过10层，超过则报错
+                    if (nextDepth > 10) {
+                        throw new IllegalStateException("Circular reference detected or nesting is too deep (over 10 levels) for: " + valueExp);
+                    }
+                    // 检查深度是否超过3层，超过则打印警告
+                    if (nextDepth > 3) {
+                        System.err.println("Solon-Warning: Configuration property nesting is deep ("
+                                + nextDepth + " levels). Check for potential circular references: " + valueExp);
+                    }
+
+                    // 递归调用，并传入递增后的深度
+                    value = getByTmlCheckDepth(main, target, value, refKey, useDef, nextDepth);
+                }
 
                 if (value == null) {
                     return null;


### PR DESCRIPTION
### 这个PR有什么用 / 我们为什么需要它？
解决配置项中自引用或者交叉引用导致加载配置文件死循环的问题。修改bug https://github.com/opensolon/solon/issues/388

### 总结您的更改
增加了计数器记录迭代层数，超过三层打印警告进行提示，超过10层报错，方便排查问题。

#### 请注明您已完成以下工作：

- [x] 确保测试通过，并在需要时添加测试覆盖率。
- [x] 确保提交消息遵循 [常规提交规范](https://www.conventionalcommits.org/) 的规则。
- [x] 考虑文档的影响，如果需要，打开一个新的文档问题或文档更改的PR。